### PR TITLE
Media Name Lookup Fixes #61, fixes #64, fixes #62

### DIFF
--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -66,7 +66,6 @@ namespace HomeSystem_CSharp
                 return;
             }
 
-            Console.WriteLine(dir);
             InitializeComponent(); // place this lower so that it doesnt black screen for so long while it finds the file
             video.Source = new Uri(dir);
 
@@ -100,9 +99,8 @@ namespace HomeSystem_CSharp
         {
             string[] movieFiles = Directory.GetFiles(movieDir, "*.*", SearchOption.AllDirectories);
             string[] musicFiles = Directory.GetFiles(musicDir, "*.*", SearchOption.AllDirectories);
-            ArrayList possibleMatches = new ArrayList();
-
             string[] splitCommand = command.Split(' ');
+            ArrayList possibleMatches = new ArrayList();
 
             //maybe change up the order it does this, i'm thinking this may be a slower way to do it but i'm not sure...
             for (int x = 2; x < splitCommand.Length; x++) // starting at 2 beacuse the first 2 words are guarenteed NOT to be in the title, so just failsafe(ish)
@@ -133,12 +131,15 @@ namespace HomeSystem_CSharp
 
             }
             if (possibleMatches.Count != 0) // if there were matches
+            {
+                if (possibleMatches.Count == 1)
+                    return possibleMatches[0].ToString();
                 for (int x = 0; x < possibleMatches.Count; x++) // now to weed out the useless matches, and get the one that fits the best
                 {
 
                 }
-            else
-                return null;
+            }
+            return null;
 
             /*
             for (int x = 0; x < movieFiles.Length; x++)

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -51,9 +51,6 @@ namespace HomeSystem_CSharp
         public const string movieDir = "G:\\Media\\Movies\\MP4\\";
         ///////////////////////////////////////////////
 
-        private string[] musicFiles, movieFiles;
-        private int fileIndex = 0, mediaType = 0; // media type is 0 = neither, 1 = movie, 2 = music
-
         public MediaWindow(string title)
         {
             // we want the media indexing to take place here. Every time this is launched, we want it to check for new media.
@@ -63,12 +60,13 @@ namespace HomeSystem_CSharp
             
             InitializeComponent();
 
-            if (mediaType == 1)
-                video.Source = new Uri(movieFiles[fileIndex]);
-            else if (mediaType == 2)
-                video.Source = new Uri(musicFiles[fileIndex]);
-            else
+            string dir = findFile(title);
+            if (dir == null)
+            {
+                Console.WriteLine("Unable to find media file, invalid directory.");
                 return;
+            }
+            video.Source = new Uri(dir);
 
             play();
             setVolume(1);
@@ -95,28 +93,26 @@ namespace HomeSystem_CSharp
             video.Volume = i;
         }
 
-        private void findFile(string title)
+        private string findFile(string title)
         {
-            movieFiles = Directory.GetFiles(movieDir, "*.*", SearchOption.AllDirectories);
-            musicFiles = Directory.GetFiles(musicDir, "*.*", SearchOption.AllDirectories);
+            string[] movieFiles = Directory.GetFiles(movieDir, "*.*", SearchOption.AllDirectories);
+            string[] musicFiles = Directory.GetFiles(musicDir, "*.*", SearchOption.AllDirectories);
             for (int x = 0; x < movieFiles.Length; x++)
             {
                 if (movieFiles[x].Contains(title))
                 {
-                    fileIndex = x;
-                    mediaType = 1;
-                    break;
+                    return movieFiles[x];
                 }
             }
             for (int x = 0; x < musicFiles.Length; x++)
             {
                 if (musicFiles[x].Contains(title))
                 {
-                    fileIndex = x;
-                    mediaType = 2;
-                    break;
+                    return musicFiles[x];
                 }
             }
+
+            return null;
         }
     }
 }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -164,6 +164,36 @@ namespace HomeSystem_CSharp
                 if (bestMatches.Count > 1) // multiple entries
                 {
                     // implement asking method to see which one was meant, and return that one.
+                    Console.WriteLine("There are multiple options for you to chose from. Please pick one:");
+                    for (int i = 0; i < bestMatches.Count; i++)
+                    {
+                        Console.WriteLine((i + 1) + ": " + bestMatches[i]);
+                    }
+                    switch (Console.ReadKey().Key)
+                    {
+                        case ConsoleKey.D1:
+                            return bestMatches[0].ToString();
+                        case ConsoleKey.D2:
+                            return bestMatches[1].ToString();
+                        case ConsoleKey.D3:
+                            return bestMatches[2].ToString();
+                        case ConsoleKey.D4:
+                            return bestMatches[3].ToString();
+                        case ConsoleKey.D5:
+                            return bestMatches[4].ToString();
+                        case ConsoleKey.D6:
+                            return bestMatches[5].ToString();
+                        case ConsoleKey.D7:
+                            return bestMatches[6].ToString();
+                        case ConsoleKey.D8:
+                            return bestMatches[7].ToString();
+                        case ConsoleKey.D9:
+                            return bestMatches[8].ToString();
+                        case ConsoleKey.D0:
+                            return bestMatches[9].ToString();
+                        default:
+                            return null;
+                    }
                 }
                 return bestMatch;
             }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -39,6 +39,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.IO;
+using System.Collections;
 
 namespace HomeSystem_CSharp
 {
@@ -51,22 +52,22 @@ namespace HomeSystem_CSharp
         public const string movieDir = "G:\\Media\\Movies\\MP4\\";
         ///////////////////////////////////////////////
 
-        public MediaWindow(string title)
+        public MediaWindow(string c)
         {
             // we want the media indexing to take place here. Every time this is launched, we want it to check for new media.
             // file name will be the only thing passed through to the dir, so we need it to be able to figure out where. for
             // threading purposes, lets just keep it localized to this mediawindow for now
-            findFile(title);
             
-            InitializeComponent();
-
-            string dir = findFile(title);
+            string dir = findFile(c);
             if (dir == null)
             {
                 Console.WriteLine("Unable to find media file, invalid directory.");
+                this.Close();
                 return;
             }
             video.Source = new Uri(dir);
+
+            InitializeComponent(); // place this lower so that it doesnt black screen for so long while it finds the file
 
             play();
             setVolume(1);
@@ -93,26 +94,60 @@ namespace HomeSystem_CSharp
             video.Volume = i;
         }
 
-        private string findFile(string title)
+        private string findFile(string command)
         {
             string[] movieFiles = Directory.GetFiles(movieDir, "*.*", SearchOption.AllDirectories);
             string[] musicFiles = Directory.GetFiles(musicDir, "*.*", SearchOption.AllDirectories);
-            for (int x = 0; x < movieFiles.Length; x++)
+            ArrayList possibleMatches = new ArrayList();
+
+            string[] splitCommand = command.Split(' ');
+
+            //maybe change up the order it does this, i'm thinking this may be a slower way to do it but i'm not sure...
+            for (int x = 2; x < splitCommand.Length; x++) // starting at 2 beacuse the first 2 words are guarenteed NOT to be in the title, so just failsafe(ish)
             {
-                if (movieFiles[x].Contains(title))
+                string commandWord = splitCommand[x];
+
+                for (int y = 0; y < movieFiles.Length; y++) // search whole list of movie files
                 {
-                    return movieFiles[x];
+                    string movieTitle = movieFiles[y].Split('\\').Last();
+                    movieTitle = movieTitle.Split('.').First();
+
+                    if (movieTitle.Contains(commandWord)) // if this specific movie file dir contains the command word
+                    {
+                        possibleMatches.Add(movieFiles[y]);
+                    }
                 }
-            }
-            for (int x = 0; x < musicFiles.Length; x++)
-            {
-                if (musicFiles[x].Contains(title))
+
+                for (int z = 0; z < musicFiles.Length; z++) // search whole list of music files
                 {
-                    return musicFiles[x];
+                    string musicTitle = musicFiles[z].Split('\\').Last();
+                    musicTitle = musicTitle.Split('.').First();
+
+                    if (musicTitle.Contains(commandWord)) // if this specific music file dir contains the command word
+                    {
+                        possibleMatches.Add(musicFiles[z]);
+                    }
                 }
             }
 
-            return null;
+                /*
+                for (int x = 0; x < movieFiles.Length; x++)
+                {
+                    if (movieFiles[x].Contains(command))
+                    {
+                        return movieFiles[x];
+                    }
+                }
+                for (int x = 0; x < musicFiles.Length; x++)
+                {
+                    if (musicFiles[x].Contains(command))
+                    {
+                        return musicFiles[x];
+                    }
+                }
+                */
+
+                return null;
         }
     }
 }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -121,8 +121,10 @@ namespace HomeSystem_CSharp
                 int wordsMatched = 0; // in this forloop because i want the value to reset for the next title
                 for (int b = 2; b < splitCommand.Length; b++) // might as well start at 2, the movie name wont be there anyway cause of command words
                 {
-                    if (title.Contains(splitCommand[b])) // if the title contains one of the words in the command line
-                        wordsMatched++;
+                    for (int c = 0; c < titleSplit.Length; c++)
+                        if (titleSplit[c] == splitCommand[b])
+                            wordsMatched++;
+                    
                     if (wordsMatched == titleLength) // if the number of words matched == the number of words in teh title, return that as there's no way that's not the right one
                         return movieFiles[a];
                 }
@@ -137,9 +139,10 @@ namespace HomeSystem_CSharp
                 int wordsMatched = 0; // in this forloop because i want the value to reset for the next title
                 for (int b = 2; b < splitCommand.Length; b++) // might as well start at 2, the movie name wont be there anyway cause of command words
                 {
-                    if (title.Contains(splitCommand[b])) // if the title contains one of the words in the command line
-                        wordsMatched++;
-
+                    for (int c = 0; c < titleSplit.Length; c++)
+                        if (titleSplit[c] == splitCommand[b])
+                            wordsMatched++;
+                    
                     if (wordsMatched == titleLength) // if the number of words matched == the number of words in teh title, return that as there's no way that's not the right one
                         return musicFiles[a];
                 }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -67,6 +67,7 @@ namespace HomeSystem_CSharp
             }
 
             InitializeComponent(); // place this lower so that it doesnt black screen for so long while it finds the file
+            Console.WriteLine(dir);
             video.Source = new Uri(dir);
 
 
@@ -129,17 +130,21 @@ namespace HomeSystem_CSharp
             for (int a = 0; a < musicFiles.Length; a++) // for music
             {
                 string title = musicFiles[a].Split('\\').Last();
-                int titleLength = title.Length;
+                title = title.Split('.').First();
+                string[] titleSplit = title.Split(' '); // this is used ONLY for getting the number of words in a title
+                int titleLength = titleSplit.Length;
 
                 int wordsMatched = 0; // in this forloop because i want the value to reset for the next title
                 for (int b = 2; b < splitCommand.Length; b++) // might as well start at 2, the movie name wont be there anyway cause of command words
                 {
                     if (title.Contains(splitCommand[b])) // if the title contains one of the words in the command line
                         wordsMatched++;
+
                     if (wordsMatched == titleLength) // if the number of words matched == the number of words in teh title, return that as there's no way that's not the right one
                         return musicFiles[a];
                 }
             }
+
             return null;
         }
     }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -110,92 +110,35 @@ namespace HomeSystem_CSharp
             for (int i = 0; i < splitCommand.Length; i++)
                 splitCommand[i] = splitCommand[i].ToLower();
 
-            //maybe change up the order it does this, i'm thinking this may be a slower way to do it but i'm not sure...
-            for (int x = 2; x < splitCommand.Length; x++) // starting at 2 beacuse the first 2 words are guarenteed NOT to be in the title, so just failsafe(ish)
+            for (int a = 0; a < movieFiles.Length; a++) // for movies
             {
-                string commandWord = splitCommand[x];
+                string title = movieFiles[a].Split('\\').Last();
+                title = title.Split('.').First();
+                string[] titleSplit = title.Split(' '); // this is used ONLY for getting the number of words in a title
+                int titleLength = titleSplit.Length;
 
-                for (int y = 0; y < movieFiles.Length; y++) // search whole list of movie files
+                int wordsMatched = 0; // in this forloop because i want the value to reset for the next title
+                for (int b = 2; b < splitCommand.Length; b++) // might as well start at 2, the movie name wont be there anyway cause of command words
                 {
-                    string movieTitle = movieFiles[y].Split('\\').Last();
-                    movieTitle = movieTitle.Split('.').First();
-
-                    if (movieTitle.Contains(commandWord)) // if this specific movie file dir contains the command word
-                    {
-                        possibleMatches.Add(movieFiles[y]);
-                    }
+                    if (title.Contains(splitCommand[b])) // if the title contains one of the words in the command line
+                        wordsMatched++;
+                    if (wordsMatched == titleLength) // if the number of words matched == the number of words in teh title, return that as there's no way that's not the right one
+                        return movieFiles[a];
                 }
-
-                for (int z = 0; z < musicFiles.Length; z++) // search whole list of music files
-                {
-                    string musicTitle = musicFiles[z].Split('\\').Last();
-                    musicTitle = musicTitle.Split('.').First();
-
-                    if (musicTitle.Contains(commandWord)) // if this specific music file dir contains the command word
-                    {
-                        possibleMatches.Add(musicFiles[z]);
-                    }
-                }
-
             }
-
-            if (possibleMatches.Count != 0) // if there were matches
+            for (int a = 0; a < musicFiles.Length; a++) // for music
             {
-                if (possibleMatches.Count == 1) // if there was only one match
-                    return possibleMatches[0].ToString();
+                string title = musicFiles[a].Split('\\').Last();
+                int titleLength = title.Length;
 
-                string bestMatch = "";
-                int bestMatchSize = 0;
-                ArrayList bestMatches = new ArrayList();
-                for (int x = 0; x < possibleMatches.Count; x++) // sorts the best match
+                int wordsMatched = 0; // in this forloop because i want the value to reset for the next title
+                for (int b = 2; b < splitCommand.Length; b++) // might as well start at 2, the movie name wont be there anyway cause of command words
                 {
-                    int wordsMatched = 0; // yes, default would be one, however this will be easier
-                    for (int i = 0; i < splitCommand.Length; i++)
-                    {
-                        string commandWord = splitCommand[i];
-                        if (possibleMatches[x].ToString().Contains(commandWord))
-                            wordsMatched++;
-                    }
-                    if (wordsMatched > bestMatchSize)
-                        bestMatch = possibleMatches[x].ToString();
-                    if (wordsMatched == bestMatchSize)
-                        bestMatches.Add(possibleMatches[x].ToString());
+                    if (title.Contains(splitCommand[b])) // if the title contains one of the words in the command line
+                        wordsMatched++;
+                    if (wordsMatched == titleLength) // if the number of words matched == the number of words in teh title, return that as there's no way that's not the right one
+                        return musicFiles[a];
                 }
-                if (bestMatches.Count > 1) // multiple entries
-                {
-                    // implement asking method to see which one was meant, and return that one.
-                    Console.WriteLine("There are multiple options for you to chose from. Please pick one:");
-                    for (int i = 0; i < bestMatches.Count; i++)
-                    {
-                        Console.WriteLine((i + 1) + ": " + bestMatches[i]);
-                    }
-                    switch (Console.ReadKey().Key)
-                    {
-                        case ConsoleKey.D1:
-                            return bestMatches[0].ToString();
-                        case ConsoleKey.D2:
-                            return bestMatches[1].ToString();
-                        case ConsoleKey.D3:
-                            return bestMatches[2].ToString();
-                        case ConsoleKey.D4:
-                            return bestMatches[3].ToString();
-                        case ConsoleKey.D5:
-                            return bestMatches[4].ToString();
-                        case ConsoleKey.D6:
-                            return bestMatches[5].ToString();
-                        case ConsoleKey.D7:
-                            return bestMatches[6].ToString();
-                        case ConsoleKey.D8:
-                            return bestMatches[7].ToString();
-                        case ConsoleKey.D9:
-                            return bestMatches[8].ToString();
-                        case ConsoleKey.D0:
-                            return bestMatches[9].ToString();
-                        default:
-                            return null;
-                    }
-                }
-                return bestMatch;
             }
             return null;
         }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -102,6 +102,14 @@ namespace HomeSystem_CSharp
             string[] splitCommand = command.Split(' ');
             ArrayList possibleMatches = new ArrayList();
 
+            //set all of the array's to lowercase, because why the hell do we need them uppercase
+            for (int i = 0; i < movieFiles.Length; i++)
+                movieFiles[i] = movieFiles[i].ToLower();
+            for (int i = 0; i < musicFiles.Length; i++)
+                musicFiles[i] = musicFiles[i].ToLower();
+            for (int i = 0; i < splitCommand.Length; i++)
+                splitCommand[i] = splitCommand[i].ToLower();
+
             //maybe change up the order it does this, i'm thinking this may be a slower way to do it but i'm not sure...
             for (int x = 2; x < splitCommand.Length; x++) // starting at 2 beacuse the first 2 words are guarenteed NOT to be in the title, so just failsafe(ish)
             {

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -134,29 +134,24 @@ namespace HomeSystem_CSharp
             {
                 if (possibleMatches.Count == 1)
                     return possibleMatches[0].ToString();
+
+                string bestMatch = "";
+                int bestMatchSize = 0;
                 for (int x = 0; x < possibleMatches.Count; x++) // now to weed out the useless matches, and get the one that fits the best
                 {
-
+                    int wordsMatched = 0; // yes, default would be one, however this will be easier
+                    for (int i = 0; i < splitCommand.Length; i++)
+                    {
+                        string commandWord = splitCommand[i];
+                        if (possibleMatches[x].ToString().Contains(commandWord))
+                            wordsMatched++;
+                    }
+                    if (wordsMatched > bestMatchSize)
+                        bestMatch = possibleMatches[x].ToString();
                 }
+                return bestMatch;
             }
             return null;
-
-            /*
-            for (int x = 0; x < movieFiles.Length; x++)
-            {
-                if (movieFiles[x].Contains(command))
-                {
-                    return movieFiles[x];
-                }
-            }
-            for (int x = 0; x < musicFiles.Length; x++)
-            {
-                if (musicFiles[x].Contains(command))
-                {
-                    return musicFiles[x];
-                }
-            }
-            */
         }
     }
 }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -46,7 +46,7 @@ namespace HomeSystem_CSharp
 
     public partial class MediaWindow : Window
     {
-        
+
         // these are austin's dirs
         public const string musicDir = "G:\\Media\\Music\\";
         public const string movieDir = "G:\\Media\\Movies\\MP4\\";
@@ -57,7 +57,7 @@ namespace HomeSystem_CSharp
             // we want the media indexing to take place here. Every time this is launched, we want it to check for new media.
             // file name will be the only thing passed through to the dir, so we need it to be able to figure out where. for
             // threading purposes, lets just keep it localized to this mediawindow for now
-            
+
             string dir = findFile(c);
             if (dir == null)
             {
@@ -65,9 +65,11 @@ namespace HomeSystem_CSharp
                 this.Close();
                 return;
             }
+
+            Console.WriteLine(dir);
+            InitializeComponent(); // place this lower so that it doesnt black screen for so long while it finds the file
             video.Source = new Uri(dir);
 
-            InitializeComponent(); // place this lower so that it doesnt black screen for so long while it finds the file
 
             play();
             setVolume(1);
@@ -128,26 +130,29 @@ namespace HomeSystem_CSharp
                         possibleMatches.Add(musicFiles[z]);
                     }
                 }
+
             }
-
-                /*
-                for (int x = 0; x < movieFiles.Length; x++)
-                {
-                    if (movieFiles[x].Contains(command))
-                    {
-                        return movieFiles[x];
-                    }
-                }
-                for (int x = 0; x < musicFiles.Length; x++)
-                {
-                    if (musicFiles[x].Contains(command))
-                    {
-                        return musicFiles[x];
-                    }
-                }
-                */
-
+            if (possibleMatches.Count == 0)
                 return null;
+
+            return possibleMatches[0].ToString();
+
+            /*
+            for (int x = 0; x < movieFiles.Length; x++)
+            {
+                if (movieFiles[x].Contains(command))
+                {
+                    return movieFiles[x];
+                }
+            }
+            for (int x = 0; x < musicFiles.Length; x++)
+            {
+                if (musicFiles[x].Contains(command))
+                {
+                    return musicFiles[x];
+                }
+            }
+            */
         }
     }
 }

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -132,10 +132,13 @@ namespace HomeSystem_CSharp
                 }
 
             }
-            if (possibleMatches.Count == 0)
-                return null;
+            if (possibleMatches.Count != 0) // if there were matches
+                for (int x = 0; x < possibleMatches.Count; x++) // now to weed out the useless matches, and get the one that fits the best
+                {
 
-            return possibleMatches[0].ToString();
+                }
+            else
+                return null;
 
             /*
             for (int x = 0; x < movieFiles.Length; x++)

--- a/MediaWindow.xaml.cs
+++ b/MediaWindow.xaml.cs
@@ -130,14 +130,16 @@ namespace HomeSystem_CSharp
                 }
 
             }
+
             if (possibleMatches.Count != 0) // if there were matches
             {
-                if (possibleMatches.Count == 1)
+                if (possibleMatches.Count == 1) // if there was only one match
                     return possibleMatches[0].ToString();
 
                 string bestMatch = "";
                 int bestMatchSize = 0;
-                for (int x = 0; x < possibleMatches.Count; x++) // now to weed out the useless matches, and get the one that fits the best
+                ArrayList bestMatches = new ArrayList();
+                for (int x = 0; x < possibleMatches.Count; x++) // sorts the best match
                 {
                     int wordsMatched = 0; // yes, default would be one, however this will be easier
                     for (int i = 0; i < splitCommand.Length; i++)
@@ -148,6 +150,12 @@ namespace HomeSystem_CSharp
                     }
                     if (wordsMatched > bestMatchSize)
                         bestMatch = possibleMatches[x].ToString();
+                    if (wordsMatched == bestMatchSize)
+                        bestMatches.Add(possibleMatches[x].ToString());
+                }
+                if (bestMatches.Count > 1) // multiple entries
+                {
+                    // implement asking method to see which one was meant, and return that one.
                 }
                 return bestMatch;
             }

--- a/Program.cs
+++ b/Program.cs
@@ -94,7 +94,6 @@ namespace HomeSystem_CSharp
         private static void ShowMediaWindow()
         {
             (mediaPlayer = new MediaWindow(mediaDir)).ShowDialog();
-
         }
 
         public static Thread getMediaThread()

--- a/Program.cs
+++ b/Program.cs
@@ -93,7 +93,11 @@ namespace HomeSystem_CSharp
 
         private static void ShowMediaWindow()
         {
-            (mediaPlayer = new MediaWindow(mediaDir)).ShowDialog();
+            try
+            {
+                (mediaPlayer = new MediaWindow(mediaDir)).ShowDialog();
+            }
+            catch (System.InvalidOperationException) { }
         }
 
         public static Thread getMediaThread()

--- a/Program.cs
+++ b/Program.cs
@@ -94,6 +94,7 @@ namespace HomeSystem_CSharp
         private static void ShowMediaWindow()
         {
             (mediaPlayer = new MediaWindow(mediaDir)).ShowDialog();
+
         }
 
         public static Thread getMediaThread()

--- a/command.cs
+++ b/command.cs
@@ -57,7 +57,7 @@ namespace HomeSystem_CSharp
             c.ToLower();
 
             string actionCommand = c.Split(' ').First();
-            
+
             switch (actionCommand)
             {
                 case "play":
@@ -137,7 +137,7 @@ namespace HomeSystem_CSharp
                 Console.WriteLine("Cannot invoke command " + s + ", mediaPlayer returned NULL");
                 return;
             }
-            
+
             switch (s)
             {
                 case "stop":

--- a/command.cs
+++ b/command.cs
@@ -57,12 +57,7 @@ namespace HomeSystem_CSharp
             c.ToLower();
 
             string actionCommand = c.Split(' ').First();
-
-            int position = c.LastIndexOf(' ');
-            string fileName = "";
-            if (position > -1)
-                fileName = c.Substring(position + 1);
-
+            
             switch (actionCommand)
             {
                 case "play":
@@ -74,7 +69,11 @@ namespace HomeSystem_CSharp
                         else
                         {
                             // get the media file name + .extenstion here
-                            Program.startNewMedia(fileName);
+                            //int position = c.LastIndexOf(' ');
+                            //string fileName = "";
+                            //if (position > -1)
+                            //    fileName = c.Substring(position + 1);
+                            Program.startNewMedia(c);
                         }
                     }
                     else

--- a/command.cs
+++ b/command.cs
@@ -69,7 +69,6 @@ namespace HomeSystem_CSharp
                 case "start":
                     if (containsMusic(c) || containsVideo(c))
                     {
-                        Console.WriteLine(fileName);
                         if (Program.getMediaThread().IsAlive)
                             invoke("play");
                         else

--- a/command.cs
+++ b/command.cs
@@ -125,7 +125,7 @@ namespace HomeSystem_CSharp
                     break;
                 default:
                     Console.WriteLine("There was no valid action command, please try again");
-                    return false;
+                    break;
             }
             return true;
         }


### PR DESCRIPTION
We're now able to dynamically look up song names. Keep in mind that it has to be an exact match, which is fine. PulsePanda's media library song list is all jacked with naming, but it does work! HUZZAH